### PR TITLE
Use separator defined in options when building a gs1 string in ToString

### DIFF
--- a/src/SimpleSoft.Gs1Parser/Gs1.cs
+++ b/src/SimpleSoft.Gs1Parser/Gs1.cs
@@ -6,15 +6,19 @@ internal class Gs1 : Dictionary<string, Gs1ApplicationIdentifier>, IGs1
 {
     private string _toString;
 
-    public Gs1(string rawValue) : base(StringComparer.OrdinalIgnoreCase)
+
+    public Gs1(string rawValue, char? separator) : base(StringComparer.OrdinalIgnoreCase)
     {
         rawValue.NotNull(nameof(rawValue));
         rawValue.NotNullOrWhiteSpace(nameof(rawValue));
 
         RawValue = rawValue;
+
+        this.Separator = separator.Value;
     }
 
     public string RawValue { get; }
+    private char Separator { get; }
 
     public override string ToString()
     {
@@ -22,7 +26,7 @@ internal class Gs1 : Dictionary<string, Gs1ApplicationIdentifier>, IGs1
         {
             var sb = new StringBuilder();
             foreach (var value in Values) 
-                sb.Append(value).Append(';');
+                sb.Append(value).Append(this.Separator);
             _toString = sb.ToString();
         }
 

--- a/src/SimpleSoft.Gs1Parser/Gs1Parser.cs
+++ b/src/SimpleSoft.Gs1Parser/Gs1Parser.cs
@@ -30,7 +30,7 @@ public class Gs1Parser : IGs1Parser
     /// <inheritdoc />
     public IGs1 Parse(string rawValue)
     {
-        var gs1 = new Gs1(rawValue);
+        var gs1 = new Gs1(rawValue, _options.Separator);
         var idx = 0;
         do
         {

--- a/tests/SimpleSoft.Gs1Parser.Tests/Gs1ParserTests.cs
+++ b/tests/SimpleSoft.Gs1Parser.Tests/Gs1ParserTests.cs
@@ -1,4 +1,6 @@
-﻿namespace SimpleSoft.Gs1Parser;
+﻿using Newtonsoft.Json.Linq;
+
+namespace SimpleSoft.Gs1Parser;
 
 public class Gs1ParserTests
 {
@@ -124,5 +126,18 @@ public class Gs1ParserTests
         });
 
         Assert.Contains("doesn't have minimum length of 1", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("10AB111", ';' , "AB111")]
+    [InlineData("10AB111", '-', "AB111")]
+    public void Parse_GS1_ToString_Uses_Separator(string rawValue, char separator, string datacontext)
+    {
+        var options = new Gs1ParserOptions() { Separator = separator };
+        var parser = new Gs1Parser(options);
+
+        var gs1 = parser.Parse(rawValue);
+
+        Assert.Equal(gs1.ToString(), $"(10){datacontext}{separator}");
     }
 }


### PR DESCRIPTION
If a the parser is configured to use a specific separator for the GS1 codes then also use that parser in ToString() on the GS1 object. This probably does not fit in architecturally & but it was convenient for my use.